### PR TITLE
add HW files

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,45 @@
 # d1manxoloda_platform
 d1manxoloda Platform repository
+
+## Домашнее задание №1
+- [x] **Основное ДЗ:**
+Разберитесь почему все pod в namespace **kube-system** восстановились после удаления
+#### Ответ:
+Причина почему все pod-ы в namespace **kube-system** восстановились, заключается в том что все pod-ы за исключением coredns
+являются [static pod-ами] и управляются напрямую.
+Pod **coredns** описан в деплойменте неймспейса kube-system.
+
+Dockerfile
+- Создан докерфайл, описывающий образ веб-сервера, прослушивающего порт 8000 и позволяющего просматривать файлы из директории app.
+- Собран образ d1manxoloda/mynginx:otus, на основе alpine и запушен в Dockerhub.
+
+Манифест pod
+- Создан манифест web-pod.yaml
+- В манифест добавлен initContainer, генерирующий index.html.
+- Добален Volumes для доступности генерируемых в initContainers файлов в контейнере web.
+- Под запущен, выполнена переадресация портов пода, веб-сервер работает, страница открывается.
+  ```
+  kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
+  ```
+
+Hipster ShopHipster Shop
+- Склонирован [репозиторий](https://github.com/GoogleCloudPlatform/microservices-demo).
+- На основе имеющегося в репозитории dockerfile собран и запушен в dockerhub образ d1manxoloda/hipster-shop:otus
+- Сгенерирован манифест frontend-pod.yaml.
+- Выполнен запуск пода с манифкста frontend-pod.yaml, под находится в статусе Error.
+  ```
+  kubectl run frontend --image d1manxoloda/hipster-shop:otus --restart=Never --dry-run -o yaml > frontend-pod.yaml
+  ```
+Hipster Shop | Задание со ⭐
+- Под frontend находится в статусе Error, из-за отсутствия env:
+  ```
+  panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
+  panic: environment variable "CURRENCY_SERVICE_ADDR" not set
+  panic: environment variable "CART_SERVICE_ADDR" not set
+  panic: environment variable "RECOMMENDATION_SERVICE_ADDR" not set
+  panic: environment variable "CHECKOUT_SERVICE_ADDR" not set
+  panic: environment variable "SHIPPING_SERVICE_ADDR" not set
+  panic: environment variable "AD_SERVICE_ADDR" not set
+  ```
+- Создан новый манифест frontend-pod-healthy.yaml, с указанием env.
+- Запущенный с манифеста frontend-pod-healthy.yaml, под frontend находится в статусе Running.

--- a/kubernetes-intro/frontend-pod-healthy.yaml
+++ b/kubernetes-intro/frontend-pod-healthy.yaml
@@ -1,0 +1,27 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+    - image: d1manxoloda/hipster-shop:otus
+      name: frontend
+      env:
+        - name: PRODUCT_CATALOG_SERVICE_ADDR
+          value: "productcatalogservice:3550"
+        - name: CURRENCY_SERVICE_ADDR
+          value: "currencyservice:7000"
+        - name: CART_SERVICE_ADDR
+          value: "cartservice:7070"
+        - name: RECOMMENDATION_SERVICE_ADDR
+          value: "recommendationservice:8080"
+        - name: CHECKOUT_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: SHIPPING_SERVICE_ADDR
+          value: "checkoutservice:5050"
+        - name: AD_SERVICE_ADDR
+          value: "adservice:9555"
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never

--- a/kubernetes-intro/frontend-pod.yaml
+++ b/kubernetes-intro/frontend-pod.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  creationTimestamp: null
+  labels:
+    run: frontend
+  name: frontend
+spec:
+  containers:
+  - image: d1manxoloda/hipster-shop:otus
+    name: frontend
+    resources: {}
+  dnsPolicy: ClusterFirst
+  restartPolicy: Never
+status: {}

--- a/kubernetes-intro/web-pod.yaml
+++ b/kubernetes-intro/web-pod.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: web
+  labels:
+    app: web
+spec:
+  containers:
+  - name: web
+    image: d1manxoloda/mynginx:otus
+    resources: {}
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  initContainers:
+  - name: init-web
+    image: busybox:1.31.0
+    command: ['sh', '-c', 'wget -O- https://tinyurl.com/otus-k8s-intro | sh']
+    volumeMounts:
+    - name: app
+      mountPath: /app
+  volumes:
+  - name: app
+    emptyDir: {}

--- a/kubernetes-intro/web/Dockerfile
+++ b/kubernetes-intro/web/Dockerfile
@@ -1,0 +1,11 @@
+FROM nginx:1.25
+
+RUN mkdir /app/ && \
+    usermod -u 1001 nginx && groupmod -g 1001 nginx
+    
+EXPOSE 8000
+
+COPY nginx.conf /etc/nginx/nginx.conf
+COPY index.html /app/
+
+CMD ["nginx", "-g", "daemon off;"]

--- a/kubernetes-intro/web/index.html
+++ b/kubernetes-intro/web/index.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Otus-kuber-2023-06</title>
+</head>
+<body>
+<h1>Hello world!</>
+</body>
+</html>

--- a/kubernetes-intro/web/nginx.conf
+++ b/kubernetes-intro/web/nginx.conf
@@ -1,0 +1,44 @@
+worker_processes  1;
+
+error_log  /dev/stdout info;
+pid        /tmp/nginx.pid;
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                      '$status $body_bytes_sent "$http_referer" '
+                      '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+
+    keepalive_timeout  65;
+
+    client_body_temp_path /tmp/client_temp;
+    proxy_temp_path       /tmp/proxy_temp_path;
+    fastcgi_temp_path     /tmp/fastcgi_temp;
+    uwsgi_temp_path       /tmp/uwsgi_temp;
+    scgi_temp_path        /tmp/scgi_temp;
+
+    server {
+    listen       8000;
+    server_name  localhost;
+
+    location / {
+        root   /app;
+        index  index.html index.htm;
+    }
+
+    error_page   500 502 503 504  /50x.html;
+    location = /50x.html {
+        root   /usr/share/nginx/html;
+    }
+    }
+}


### PR DESCRIPTION
# Выполнено ДЗ №

- [x] **Основное ДЗ:**
Разберитесь почему все pod в namespace **kube-system** восстановились после удаления
#### Ответ:
Причина почему все pod-ы в namespace **kube-system** восстановились, заключается в том что все pod-ы за исключением coredns
являются [static pod-ами] и управляются напрямую.
Pod **coredns** описан в деплойменте неймспейса kube-system.

Dockerfile
- Создан докерфайл, описывающий образ веб-сервера, прослушивающего порт 8000 и позволяющего просматривать файлы из директории app.
- Собран образ d1manxoloda/mynginx:otus, на основе alpine и запушен в Dockerhub.

Манифест pod
- Создан манифест web-pod.yaml
- В манифест добавлен initContainer, генерирующий index.html.
- Добален Volumes для доступности генерируемых в initContainers файлов в контейнере web.
- Под запущен, выполнена переадресация портов пода, веб-сервер работает, страница открывается.
  ```
  kubectl port-forward --address 0.0.0.0 pod/web 8000:8000
  ```

Hipster ShopHipster Shop
- Склонирован [репозиторий](https://github.com/GoogleCloudPlatform/microservices-demo).
- На основе имеющегося в репозитории dockerfile собран и запушен в dockerhub образ d1manxoloda/hipster-shop:otus
- Сгенерирован манифест frontend-pod.yaml.
- Выполнен запуск пода с манифкста frontend-pod.yaml, под находится в статусе Error.
  ```
  kubectl run frontend --image d1manxoloda/hipster-shop:otus --restart=Never --dry-run -o yaml > frontend-pod.yaml
  ```
Hipster Shop | Задание со *
- Под frontend находится в статусе Error, из-за отсутствия env:
  ```
  panic: environment variable "PRODUCT_CATALOG_SERVICE_ADDR" not set
  panic: environment variable "CURRENCY_SERVICE_ADDR" not set
  panic: environment variable "CART_SERVICE_ADDR" not set
  panic: environment variable "RECOMMENDATION_SERVICE_ADDR" not set
  panic: environment variable "CHECKOUT_SERVICE_ADDR" not set
  panic: environment variable "SHIPPING_SERVICE_ADDR" not set
  panic: environment variable "AD_SERVICE_ADDR" not set
  ```
- Создан новый манифест frontend-pod-healthy.yaml, с указанием env.
- Запущенный с манифеста frontend-pod-healthy.yaml, под frontend находится в статусе Running.


## Как запустить проект:
 - Например, запустить команду X в директории Y

## Как проверить работоспособность:
 - Например, перейти по ссылке http://localhost:8080

## PR checklist:
 - [x] Выставлен label с темой домашнего задания
